### PR TITLE
增加图片压缩服务

### DIFF
--- a/node_modules/hope-center/lib/hubbundles/thingbundle/compression/ImageCompression/i18n.zh-CN.json
+++ b/node_modules/hope-center/lib/hubbundles/thingbundle/compression/ImageCompression/i18n.zh-CN.json
@@ -1,0 +1,4 @@
+{
+	"compress Image": "图片压缩",
+	"compress an image by node, it's very fast and satisfactory": "通过node来压缩图片，速度很快并且效果很好"
+}

--- a/node_modules/hope-center/lib/hubbundles/thingbundle/compression/ImageCompression/kernel.js
+++ b/node_modules/hope-center/lib/hubbundles/thingbundle/compression/ImageCompression/kernel.js
@@ -1,0 +1,31 @@
+var sharp = require('sharp');
+
+// var params = {
+// 	inputPath: '/Users/W_littlewhite/Downloads/photo.jpg',
+// 	width: 800,
+// 	heigth: 600,
+// 	outputPath: '/Users/W_littlewhite/Downloads/output.jpg'
+// }
+
+var params = {
+	inputPath: IN.inputPath,
+	width: IN.width,
+	heigth: IN.height,
+	outputPath: IN.outputPath
+}
+
+function sharpImage(params) {
+	sharp(params.inputPath).resize(params.width,params.height)
+		.toFile(params.outputPath,function (err,info) {
+			if(err) {
+				console.log(err);
+				sendOUT({isSuccess: false});
+			}
+			if(info) {
+				console.log(info);
+				sendOUT({isSuccess: true});
+			}
+		});
+}
+
+sharpImage(params);

--- a/node_modules/hope-center/lib/hubbundles/thingbundle/compression/ImageCompression/kernel.js
+++ b/node_modules/hope-center/lib/hubbundles/thingbundle/compression/ImageCompression/kernel.js
@@ -1,12 +1,5 @@
 var sharp = require('sharp');
 
-// var params = {
-// 	inputPath: '/Users/W_littlewhite/Downloads/photo.jpg',
-// 	width: 800,
-// 	heigth: 600,
-// 	outputPath: '/Users/W_littlewhite/Downloads/output.jpg'
-// }
-
 var params = {
 	inputPath: IN.inputPath,
 	width: IN.width,

--- a/node_modules/hope-center/lib/hubbundles/thingbundle/compression/ImageCompression/service.json
+++ b/node_modules/hope-center/lib/hubbundles/thingbundle/compression/ImageCompression/service.json
@@ -1,0 +1,39 @@
+{
+  "type": "hope_service",
+  "name": "compress Image",
+  "description": "compress an image by node, it's very fast and satisfactory",
+  "spec": {
+    "in": {
+      "ports": [
+        {
+          "name": "inputPath",
+          "type": "string"
+        },
+		    {
+    			"name": "width",
+    			"type": "int"
+    		},
+    		{
+    			"name": "height",
+    			"type": "int"
+    		},
+    		{
+    			"name": "outputPath",
+    			"type": "string"
+    		}
+		  ]
+    },
+    "out": {
+      "ports": [
+        {
+          "name": "isSuccess",
+          "type": "boolean"
+        }
+      ]
+    },
+    "name": "compress an image",
+    "id": "SPEC__01a423b0-8d16-11e6-8763-9b23940b3719"
+  },
+  "id": "HOPE_SERVICE_01c4f220_8d16_11e6_bc0c_37460badb2df",
+  "thing": "HOPE_THING_1e0958a0_8630_11e6_bc8a_efdb136b0d2b"
+}

--- a/node_modules/hope-center/lib/hubbundles/thingbundle/compression/i18n.zh-CN.json
+++ b/node_modules/hope-center/lib/hubbundles/thingbundle/compression/i18n.zh-CN.json
@@ -1,0 +1,4 @@
+﻿{
+  "compression":"压缩文件",
+  "provide compression service":"提供压缩服务"
+}

--- a/node_modules/hope-center/lib/hubbundles/thingbundle/compression/thing.json
+++ b/node_modules/hope-center/lib/hubbundles/thingbundle/compression/thing.json
@@ -1,0 +1,5 @@
+{
+  "name": "compression",
+  "description":"provide compression service",
+  "is_builtin":true
+}

--- a/node_modules/hope-center/package.json
+++ b/node_modules/hope-center/package.json
@@ -55,7 +55,8 @@
     "sentiment": "1.0.6",
     "serialport": "4.0.*",
     "ws": "0.8.1",
-    "xml2js": "0.4.16"
+    "xml2js": "0.4.16",
+    "sharp": "*"
   },
   "devDependencies": {
     "chai": "^3.0.0",


### PR DESCRIPTION
## 新增图片压缩服务
### 输入参数：

_inputPath_: 源图片绝对路径

_width_: 目的图片的宽度

_height_: 目的图片的高度

_outputPath_: 目的图片的绝对路径
### 输出结果：

_isSuccess_: true or false

是否压缩成功

通过node添加图片压缩服务，能够在本地快速改变图片大小和图片的像素，以此来减少一些对图片进行云处理（比如图片的识别等）的时间。
