### PR TITLE
微软人脸识别API

### DIFF
--- a/center/lib/hubbundles/thingbundle/life/ms_face/i18n.zh-CN.json
+++ b/center/lib/hubbundles/thingbundle/life/ms_face/i18n.zh-CN.json
@@ -1,0 +1,5 @@
+{
+  "ms_face":"微软人脸识别",
+  "Recognize a face with the microsoft face API.":"使用微软的人脸识别API来识别人脸",
+  "builtin/life.html#ms_face":"builtin/life.zh-CN.html#微软人脸识别"
+}

--- a/center/lib/hubbundles/thingbundle/life/ms_face/kernel.js
+++ b/center/lib/hubbundles/thingbundle/life/ms_face/kernel.js
@@ -1,0 +1,9 @@
+
+shared.ms_face(IN.filepath, CONFIG.key, function(data) {
+  sendOUT({
+    out:data
+  });
+  }, function(err) {
+  sendERR(err);
+});
+

--- a/center/lib/hubbundles/thingbundle/life/ms_face/service.json
+++ b/center/lib/hubbundles/thingbundle/life/ms_face/service.json
@@ -1,0 +1,33 @@
+{
+  "name": "ms_face",
+  "description": "Recognize a face with the microsoft face API.",
+  "spec": {
+    "id": "__HOPE__/builtin/life/ms_face",
+    "name": "ms_face_spec",
+    "in": {
+      "ports": [
+        {
+          "name": "filepath",
+          "type": "string"
+        }
+      ]
+    },
+    "out": {
+      "ports": [
+        {
+          "name": "data",
+          "type": "string"
+        }
+      ]
+    },
+    "config":[
+      {
+        "name":"key",
+        "type":"string",
+        "required":true
+      }
+    ]
+  },
+  "ui": {},
+  "doc" :"builtin/life.html#ms_face"
+}

--- a/center/lib/hubbundles/thingbundle/life/ms_face/start.js
+++ b/center/lib/hubbundles/thingbundle/life/ms_face/start.js
@@ -1,0 +1,40 @@
+var fs = require('fs');
+var request = require("request");
+
+function recognize(img,key,data_handler,err_handler) {
+  var options = {
+    uri:'https://api.projectoxford.ai/face/v1.0/detect?returnFaceId=true&returnFaceLandmarks=true&returnFaceAttributes=age,gender,headPose,smile,facialHair,glasses',
+    method:'POST',
+    headers: {
+      'Content-Type':'application/octet-stream',
+      'Content-Length': img.length,
+      'Ocp-Apim-Subscription-Key':key
+    },
+    body:img
+  };
+
+  request(options, function(e, r1, res) {
+    if (e) {
+      err_handler(e);
+    } else {
+      if(res) {
+        res = JSON.parse(res);
+        data_handler(JSON.stringify(res,null,4));
+      } else {
+        err_handler("response status code " + res.statusCode + "is not 200");
+      }
+    }
+
+  });
+}
+
+shared.ms_face = function(filepath, key, data_handler, err_handler) {
+  fs.readFile(filepath,function(err,data) {
+    if(err) {
+      err_handler(err);
+    }
+    recognize(data,key,data_handler,err_handler);
+  });
+};
+
+done();

--- a/doc/md/builtin/life.md
+++ b/doc/md/builtin/life.md
@@ -228,3 +228,186 @@ You may visit [alidayu](https://api.alidayu.com/doc2/apiDetail?spm=a3142.7791109
 }
 
 ```
+
+</br>
+
+## ms_face
+
+### Description
+
+Ask for microsoft face API easily by this service, it returns the face and other features of a man. The link:https://www.azure.cn/cognitive-services/zh-cn/face-api. This is the face detection and it need not any training.
+
+### Config
+
+`keys`: String,the Ocp-Apim-Subscription-Key of you microsoft face API.
+
+### Inport
+
+`filepath`: String, the absolute path of an image. 
+
+### Outport
+
+`data`: String, it shows the response data in JSON String. A successful call returns an array of face entries ranked by face rectangle size in descending order. An empty response indicates no faces detected. A face entry may contain the following values depending on input parameters:
+
+| Fields        | Type           | Description  |
+| ------------- |:-------------:|:----- |
+| faceId      | String | Unique faceId of the detected face, created by detection API and it will expire in 24 hours after detection call. |
+| faceRectangle     | Object | A rectangle area for the face location on image. |
+| faceLandmarks | Object | An array of 27-point face landmarks pointing to the important positions of face components. |
+| faceAttributes | Object | Face Attributes:<br />* `age`: an age number in years.<br />* `gender`: male or female.<br />* `smile`: smile intensity, a number between [0,1]<br />* `facialHair`: consists of lengths of three facial hair areas: moustache, beard and sideburns.<br />* `headPose`: 3-D roll/yew/pitch angles for face direction. Pitch value is a reserved field and will always return 0.<br />* `glasses`: glasses type. Possible values are 'noGlasses', 'readingGlasses', 'sunglasses', 'swimmingGoggles'.|
+
+### Example
+
+Config:
+
+```javascript
+keys:'a507fafe438643329b2dc3c2ed9*****'
+```
+
+Inport: 
+
+```javascript
+filepath:'/Users/User/Documents/Emotion_Recognition/test.jpg'
+```
+
+Outport:
+
+```javascript
+[
+  {
+    "faceId": "48cdf8c8-841c-4d33-b875-1710a3fc6542",
+    "faceRectangle": {
+      "width": 228,
+      "height": 228,
+      "left": 460,
+      "top": 125
+    },
+    "faceLandmarks": {
+      "pupilLeft": {
+        "x": 507,
+        "y": 204.9
+      },
+      "pupilRight": {
+        "x": 609.8,
+        "y": 175.4
+      },
+      "noseTip": {
+        "x": 596.4,
+        "y": 250.9
+      },
+      "mouthLeft": {
+        "x": 531.4,
+        "y": 301
+      },
+      "mouthRight": {
+        "x": 629,
+        "y": 273.7
+      },
+      "eyebrowLeftOuter": {
+        "x": 463.2,
+        "y": 201.2
+      },
+      "eyebrowLeftInner": {
+        "x": 547.4,
+        "y": 177.1
+      },
+      "eyeLeftOuter": {
+        "x": 496.8,
+        "y": 212
+      },
+      "eyeLeftTop": {
+        "x": 508.8,
+        "y": 199.4
+      },
+      "eyeLeftBottom": {
+        "x": 513.2,
+        "y": 214
+      },
+      "eyeLeftInner": {
+        "x": 528.2,
+        "y": 203.2
+      },
+      "eyebrowRightInner": {
+        "x": 584.2,
+        "y": 165.4
+      },
+      "eyebrowRightOuter": {
+        "x": 630.3,
+        "y": 148.3
+      },
+      "eyeRightInner": {
+        "x": 598,
+        "y": 183.7
+      },
+      "eyeRightTop": {
+        "x": 609.5,
+        "y": 170.1
+      },
+      "eyeRightBottom": {
+        "x": 615.2,
+        "y": 181.2
+      },
+      "eyeRightOuter": {
+        "x": 627.6,
+        "y": 171.3
+      },
+      "noseRootLeft": {
+        "x": 558.2,
+        "y": 198.7
+      },
+      "noseRootRight": {
+        "x": 583.5,
+        "y": 192.2
+      },
+      "noseLeftAlarTop": {
+        "x": 558.6,
+        "y": 235.7
+      },
+      "noseRightAlarTop": {
+        "x": 601.1,
+        "y": 224.9
+      },
+      "noseLeftAlarOutTip": {
+        "x": 549.2,
+        "y": 259.4
+      },
+      "noseRightAlarOutTip": {
+        "x": 615,
+        "y": 240.9
+      },
+      "upperLipTop": {
+        "x": 591.4,
+        "y": 278.3
+      },
+      "upperLipBottom": {
+        "x": 592,
+        "y": 287.7
+      },
+      "underLipTop": {
+        "x": 591.7,
+        "y": 296.7
+      },
+      "underLipBottom": {
+        "x": 594.8,
+        "y": 313.3
+      }
+    },
+    "faceAttributes": {
+      "age": 23.5,
+      "gender": "female",
+      "headPose": {
+        "roll": -16.5,
+        "yaw": 22.1,
+        "pitch": 0
+      },
+      "smile": 0.998,
+      "facialHair": {
+        "moustache": 0,
+        "beard": 0,
+        "sideburns": 0
+      },
+      "glasses": "ReadingGlasses"
+    }
+  }
+]
+```

--- a/doc/md/builtin/life.zh-CN.md
+++ b/doc/md/builtin/life.zh-CN.md
@@ -219,3 +219,186 @@ http://www.zhihu.com/rss
 }
 
 ```
+
+</br>
+
+## 微软人脸识别服务
+
+### 描述
+
+通过封装好的请求来访问微软的人脸识别服务并获得返回结果，可以识别出人以及其表情和外貌特征。官网连接：https://www.azure.cn/cognitive-services/zh-cn/face-api。这里是使用了其识别人脸特征的功能，无需训练。
+
+### 配置
+
+`keys`: 字符串类型，该配置项需要填写在微软API服务中申请的认证码，即实际填写的是微软人脸识别服务的Ocp-Apim-Subscription-Key的值。
+
+### 输入
+
+`filepath`: 字符串类型，发送的文件路径。最好填写绝对路径以免发送未知的错误。
+
+### 输出
+
+`data`: 字符串类型，将云服务返回的结果处理成json字符串的形式显示。识别成功会返回一个数组，里面根据识别框大小的递减顺序排列。空的返回值说明没有识别到任何人脸信息。 人脸的返回值包含了如下属性:
+
+| 名称        | 类别           | 描述  |
+| ------------- |:-------------:|:----- |
+| faceId      | String | 检测出的人脸的唯一标示，24小时之后会过期。 |
+| faceRectangle     | Object | 图片中显示人脸位置的矩形区域。 |
+| faceLandmarks | Object | 由27个点组成的数组，对应人脸中27个重要的标志位。 |
+| faceAttributes | Object | 人脸的属性:<br />* `age`: 年龄。<br />* `gender`: 男或者女<br />* `smile`: 微笑的程度，返回值在0到1之间。<br />* `facialHair`: 由三种毛发特征组成，主要来描述不同的胡须位置。<br />* `headPose`: 人脸的三种位置姿态， 第三个参数为保留参数通常为0。<br />* `glasses`: 眼镜的类型，有四种可能的结果。|
+
+### 例子
+
+配置:
+
+```javascript
+keys:'a507fafe438643329b2dc3c2ed9*****'
+```
+
+输入: 
+
+```javascript
+filepath:'/Users/User/Documents/Emotion_Recognition/test.jpg'
+```
+
+输出:
+
+```javascript
+[
+  {
+    "faceId": "48cdf8c8-841c-4d33-b875-1710a3fc6542",
+    "faceRectangle": {
+      "width": 228,
+      "height": 228,
+      "left": 460,
+      "top": 125
+    },
+    "faceLandmarks": {
+      "pupilLeft": {
+        "x": 507,
+        "y": 204.9
+      },
+      "pupilRight": {
+        "x": 609.8,
+        "y": 175.4
+      },
+      "noseTip": {
+        "x": 596.4,
+        "y": 250.9
+      },
+      "mouthLeft": {
+        "x": 531.4,
+        "y": 301
+      },
+      "mouthRight": {
+        "x": 629,
+        "y": 273.7
+      },
+      "eyebrowLeftOuter": {
+        "x": 463.2,
+        "y": 201.2
+      },
+      "eyebrowLeftInner": {
+        "x": 547.4,
+        "y": 177.1
+      },
+      "eyeLeftOuter": {
+        "x": 496.8,
+        "y": 212
+      },
+      "eyeLeftTop": {
+        "x": 508.8,
+        "y": 199.4
+      },
+      "eyeLeftBottom": {
+        "x": 513.2,
+        "y": 214
+      },
+      "eyeLeftInner": {
+        "x": 528.2,
+        "y": 203.2
+      },
+      "eyebrowRightInner": {
+        "x": 584.2,
+        "y": 165.4
+      },
+      "eyebrowRightOuter": {
+        "x": 630.3,
+        "y": 148.3
+      },
+      "eyeRightInner": {
+        "x": 598,
+        "y": 183.7
+      },
+      "eyeRightTop": {
+        "x": 609.5,
+        "y": 170.1
+      },
+      "eyeRightBottom": {
+        "x": 615.2,
+        "y": 181.2
+      },
+      "eyeRightOuter": {
+        "x": 627.6,
+        "y": 171.3
+      },
+      "noseRootLeft": {
+        "x": 558.2,
+        "y": 198.7
+      },
+      "noseRootRight": {
+        "x": 583.5,
+        "y": 192.2
+      },
+      "noseLeftAlarTop": {
+        "x": 558.6,
+        "y": 235.7
+      },
+      "noseRightAlarTop": {
+        "x": 601.1,
+        "y": 224.9
+      },
+      "noseLeftAlarOutTip": {
+        "x": 549.2,
+        "y": 259.4
+      },
+      "noseRightAlarOutTip": {
+        "x": 615,
+        "y": 240.9
+      },
+      "upperLipTop": {
+        "x": 591.4,
+        "y": 278.3
+      },
+      "upperLipBottom": {
+        "x": 592,
+        "y": 287.7
+      },
+      "underLipTop": {
+        "x": 591.7,
+        "y": 296.7
+      },
+      "underLipBottom": {
+        "x": 594.8,
+        "y": 313.3
+      }
+    },
+    "faceAttributes": {
+      "age": 23.5,
+      "gender": "female",
+      "headPose": {
+        "roll": -16.5,
+        "yaw": 22.1,
+        "pitch": 0
+      },
+      "smile": 0.998,
+      "facialHair": {
+        "moustache": 0,
+        "beard": 0,
+        "sideburns": 0
+      },
+      "glasses": "ReadingGlasses"
+    }
+  }
+]
+```


### PR DESCRIPTION
# 微软人脸识别API

该服务能够更方便的使用微软的人脸识别API来获得返回的结果，可以识别出人物的面部已经外貌特征。
## 输入参数

`filepath`:需要识别的图片的绝对路径。
## 配置参数

`keys`:使用微软人脸识别服务所获得的Ocp-Apim-Subscription-Key。
## 输出结果

`data`:以JSON字符串的形式输出返回的识别结果。
## 样例图片

![image](https://cloud.githubusercontent.com/assets/12878076/19777710/1aa1a202-9cac-11e6-8821-fa977b20e3b2.png)

![image](https://cloud.githubusercontent.com/assets/12878076/19777724/279dca30-9cac-11e6-8b22-6ff9b4c47b22.png)
