### PR TITLE
Fix the bug of absolute web file paths in the config of a center.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ public/
 out
 ui-widgets/generated
 !**/.gitkeep
+/.idea

--- a/center/center
+++ b/center/center
@@ -29,7 +29,7 @@ program.name = "center";
 
 program.parse(process.argv);
 
-if (program.args.length > 1) {
+if (program.args.length == 1 && program.args[0] == '--help') {
   program.help();
 }
 
@@ -38,21 +38,21 @@ var processed_config = S.process_config(program.args[0] || "./config.json");
 var config = processed_config.generated_config;
 
 
-// TODO hard code the conversion of some paths currently, maybe need a more general solution
 function _resolve_path(access_str) {
   var x = _.get(config, access_str);
-  if (x) {
-    if (_.isArray(x)) {
-      var paths = x.map(function(p) {
-        return B.path.abs(p, config.config_path);
-      });
-      _.set(config, access_str, paths);
-    }
-    else {
-      _.set(config, access_str, B.path.abs(x, config.config_path));
-    }
+  if (_.isArray(x)) {
+    var paths = x.map(function(p) {
+      return B.path.abs(p, config.config_path);
+    });
+    _.set(config, access_str, paths);
   }
-} 
+  else {
+    _.set(config, access_str, B.path.abs(x, config.config_path));
+  }
+}
+
+_resolve_path("assemble.dev_web_app.$params.static");
+_resolve_path("assemble.user_web_app.$params.static");
 _resolve_path("assemble.user_json_path");
 
 // Fix the id of device and mnode

--- a/doc/md/app-dev/getstarted/advanced/configuration/4-Center_Specific/center.md
+++ b/doc/md/app-dev/getstarted/advanced/configuration/4-Center_Specific/center.md
@@ -7,14 +7,18 @@ In addition, there are multiple paths could be configured, e.g. where the applic
 **Center** tracks the online/offline status of **Hub** by using heartbeat. So there is a heartbeat server on **Center** and need to be configured as well.
 
 
-| config field  |   optional  |   available values  |  description |
-|:----------|:------|:----------------|:--------------------------------------|
-| web_for_developer  |  yes     |   a JSON object with port field to set | defines the web server for app developer |
-| web_for_end_users  |  yes     |   a JSON object with port field to set | defines the web server for end users |
-| app_bundle_path  |  yes     |  by defult it is "./appbundle" | where to store the applications (workflows, UI etc.) |
-| user_json_path  |  yes     |  by defult it is "./user.json" | where to store the usesr profiles |
-| authenticate | yes | true / false (default) | whether we enabled user system or not |
-| heartbeat_server|yes| a JSON object with check_interval and drop_threshold fileds| check_interval defines by every how many milliseconds the server would check the heartbeat status of all Hubs, and drop_threshold means that a Hub would be considered as offline if Center doesn't receive its heartbeat message for such long milliseconds|
+| config field           | optional | available values                         | description                              |
+| ---------------------- | :------- | :--------------------------------------- | :--------------------------------------- |
+| web_for_developer      | yes      | a JSON object with port field to set     | defines the web server for app developer |
+| web_for_end_users      | yes      | a JSON object with port field to set     | defines the web server for end users     |
+| app_bundle_path        | yes      | by defult it is "./appbundle"            | where to store the applications (workflows, UI etc.) |
+| user_json_path         | yes      | by defult it is "./user.json"            | where to store the user profiles         |
+| authenticate           | yes      | true / false (default)                   | whether we enabled user system or not    |
+| heartbeat_server       | yes      | a JSON object with check_interval and drop_threshold fileds | check_interval defines by every how many milliseconds the server would check the heartbeat status of all Hubs, and drop_threshold means that a Hub would be considered as offline if Center doesn't receive its heartbeat message for such long milliseconds |
+| static_ui_dev_path     | yes      | by default it is "../../../ui-dev"       | the path to the directory where the web page files of app development interface store. |
+| static_ui_user_path    | yes      | by default it is "../../../ui-user"      | the path to the directory where the web page files of end-user interface store. |
+| static_doc_path        | yes      | by default it is "../../../doc"          | the path to the directory where the web page files of online helping document store. |
+| static_ui_widgets_path | yes      | by default it is "../../../ui-widgets"   | the path to the directory where the UI widgets store. |
 
 
 ## Example

--- a/hub-center-shared/lib/config.js
+++ b/hub-center-shared/lib/config.js
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 var B = require("hope-base");
 var _ = require("lodash");
 
-var reldir = B.fs.dir_exists(__dirname + "/../../ui-widgets") ? "../.." : "../../..";
+var reldir = "../../..";
 
 exports.process = function(file_path) {
   return new Config(file_path);

--- a/hub-center-shared/lib/config.js
+++ b/hub-center-shared/lib/config.js
@@ -31,8 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 var B = require("hope-base");
 var _ = require("lodash");
 
-var reldir = B.fs.dir_exists(__dirname + "/../../ui-widgets") ? "/../.." : "/../../..";
-var absdir = B.path.resolve(__dirname + reldir);
+var reldir = B.fs.dir_exists(__dirname + "/../../ui-widgets") ? "../.." : "../../..";
 
 exports.process = function(file_path) {
   return new Config(file_path);
@@ -186,7 +185,11 @@ Config.prototype.gen_center_specific = function() {
       $type: "WebApp",
       $params: {
         port: _.get(this.json, "web_for_developer.port", 8080),
-        static: [absdir + "/ui-dev/public", absdir + "/doc/html", absdir + "/ui-widgets"],
+        static: [
+          _.get(this.json, "static_ui_dev_path", reldir + "/ui-dev") + "/public",
+          _.get(this.json, "static_doc_path", reldir + "/doc") + "/html",
+          _.get(this.json, "static_ui_widgets_path", reldir + "/ui-widgets")
+        ],
         web_socket: true
       }
     },
@@ -195,7 +198,10 @@ Config.prototype.gen_center_specific = function() {
       $type: "WebApp",
       $params: {
         port: _.get(this.json, "web_for_end_users.port", 3000),
-        static: [absdir + "/ui-user/public", absdir + "/ui-widgets"],
+        static: [
+          _.get(this.json, "static_ui_user_path", reldir + "/ui-user") + "/public",
+          _.get(this.json, "static_ui_widgets_path", reldir + "/ui-widgets")
+        ],
         web_socket: true
       }
     },


### PR DESCRIPTION
问题描述：由于原先在center的配置中ui-widgets,ui-user,ui-dev和doc的前端页面文件的路径被写死（路径为../../../或../../），导致开发者一旦在其它路径自行配置一个新的center的时候，浏览器就会打不开网页。

为此，我们通过允许开发者在`config.json`文件中自行配置这些前端页面文件的路径来解决这个问题。新增的配置字段为：`static_ui_dev_path`，`static_ui_user_path`，`static_doc_path`和`static_ui_widgets_path`